### PR TITLE
Add test tokenlog

### DIFF
--- a/tokenlog.json
+++ b/tokenlog.json
@@ -1,0 +1,7 @@
+{
+    "org": "MetaMask",
+    "repo": "specifications",
+    "tokenAddress": "0xf824a5f172ba61a050ebd166391a20932e036513",
+    "votingMethod": "STANDARD",
+    "chainId": 137
+}


### PR DESCRIPTION
Just experimenting with [tokenlog](https://tokenlog.xyz/) token prioritized github backlogs. This config file would tell tokenlog how to identify tokens to display a ranked backlog via.

This may not even work, b/c I'm including a chainId "they don't support" (but it might work with a query param). I might just make the changes to their repo to make it work with polygon since I used it for this test token.